### PR TITLE
Add backend deployment helper

### DIFF
--- a/Backend/README.md
+++ b/Backend/README.md
@@ -185,7 +185,19 @@ dotnet test --collect:"XPlat Code Coverage"
 
 ## Deployment
 
-The Azure Functions project can be deployed to Azure using:
+The Azure Functions project can be deployed to Azure using either the raw `func` command or the helper scripts in this repository.
+
+### Using Scripts
+From the repository root run:
+
+```powershell
+cd Backend/Scripts
+./deploy_backend.ps1 -FunctionAppName <your-function-app-name> -ProvisionInfrastructure
+```
+
+The `-ProvisionInfrastructure` switch runs the ARM template deployment found under `Deployment/Azure/Scripts` before publishing the latest code.
+
+### Manual `func` Command
 
 ### Bash/Linux/macOS:
 ```bash

--- a/Backend/Scripts/deploy_backend.ps1
+++ b/Backend/Scripts/deploy_backend.ps1
@@ -1,0 +1,20 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$FunctionAppName,
+    [string]$Configuration = "Release",
+    [switch]$ProvisionInfrastructure
+)
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptDir "..\..")
+
+if ($ProvisionInfrastructure.IsPresent) {
+    $infraScript = Join-Path $repoRoot "Deployment/Azure/Scripts/deploy_functions.ps1"
+    Write-Host "Provisioning Azure resources via $infraScript"
+    & $infraScript
+}
+
+$publishScript = Join-Path $scriptDir "publish_functions.ps1"
+Write-Host "Publishing Function App $FunctionAppName using $publishScript"
+& $publishScript -FunctionAppName $FunctionAppName -Configuration $Configuration
+

--- a/Backend/Scripts/publish_functions.ps1
+++ b/Backend/Scripts/publish_functions.ps1
@@ -1,0 +1,20 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$FunctionAppName,
+    [string]$Configuration = "Release",
+    [string]$FunctionsProjectPath = "../ServerManagement.Functions"
+)
+
+# Resolve the project path relative to this script
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$projectPath = Resolve-Path (Join-Path $scriptDir $FunctionsProjectPath)
+
+Write-Host "Publishing Functions project at $projectPath using configuration $Configuration"
+
+# Build and publish the functions project
+$publishDir = Join-Path $projectPath "bin\$Configuration\net8.0\publish"
+dotnet publish $projectPath -c $Configuration -o $publishDir
+
+# Deploy to Azure
+Write-Host "Deploying to Azure Function App: $FunctionAppName"
+func azure functionapp publish $FunctionAppName --csharp --dotnet-isolated --publish-local-settings -i

--- a/Backend/proposal.md
+++ b/Backend/proposal.md
@@ -1,0 +1,54 @@
+# Backend Deployment Proposal
+
+This document proposes a simple, script‑based approach for publishing the Azure Functions backend to the infrastructure deployed by the ARM templates.
+
+## Overview
+- Infrastructure is provisioned using the PowerShell scripts under `Deployment/Azure/Scripts`. `deploy_functions.ps1` creates the Function App using ARM templates.
+- After the Function App exists, the backend code must be published so the Functions are available.
+- Instead of a full CI/CD pipeline, we keep deployment manual via scripts checked into the repo.
+
+## Proposed Directory
+Create a new directory within `Backend`:
+
+```
+Backend/Scripts/
+```
+
+This folder will contain helper scripts for building and publishing the backend.
+
+## Publish Script
+Add a PowerShell script named `publish_functions.ps1` inside `Backend/Scripts`. Its responsibilities:
+
+1. **Build** the `ServerManagement.Functions` project (default `Release` configuration).
+2. **Publish** the project using Azure Functions Core Tools (`func azure functionapp publish`).
+3. Accept the target Function App name as a parameter and optionally the build configuration.
+
+Example usage:
+
+```powershell
+./publish_functions.ps1 -FunctionAppName my-func-app -Configuration Release
+```
+
+The script resolves the Functions project path relative to itself, runs `dotnet publish`, then executes:
+
+```powershell
+func azure functionapp publish my-func-app --csharp --dotnet-isolated --publish-local-settings -i
+```
+
+Environment variables or a small config file can be used to store the Function App name so it does not have to be typed each time.
+
+## Combined Deployment Script
+An additional script `deploy_backend.ps1` orchestrates the entire process. It can provision the Function App infrastructure and then publish the compiled code.
+
+Example usage:
+
+```powershell
+./deploy_backend.ps1 -FunctionAppName my-func-app -ProvisionInfrastructure
+```
+
+## Deployment Flow
+1. Run `Deployment/Azure/Scripts/deploy_functions.ps1` to create or update the Function App infrastructure. This script uses the ARM templates under `Deployment/Azure/Arm/Functions` (not included in the repository).
+2. After the resources exist, invoke `Backend/Scripts/publish_functions.ps1` with the Function App name to upload the latest compiled code.
+3. The Functions app will restart automatically and begin serving requests.
+
+This lightweight approach keeps deployment simple while still allowing repeatable, scripted releases without a full CI/CD pipeline.


### PR DESCRIPTION
## Summary
- implement PowerShell script to provision and publish the Azure Functions backend
- document usage in README
- expand proposal with combined deployment script guidance

## Testing
- `dotnet test Backend/ServerManagement.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a55a8ddc8325af55f7cd572327ce