### PR TITLE
Add ASP.NET Core Web API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,7 @@ Thumbs.db
 # Logs
 *.log
 logs/
+
+# Web API appsettings
+Backend/ServerManagment.WebApi/appsettings.json
+Backend/ServerManagment.WebApi/appsettings.Development.json

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -6,28 +6,29 @@ Backend solution for managing a 7 Days to Die game server running on Azure VM.
 
 - **ServerManagement.Core**: Core domain models and interfaces
 - **ServerManagement.Azure**: Azure-specific implementations for VM and game server management
-- **ServerManagement.Functions**: Azure Functions HTTP API endpoints
+- **ServerManagment.WebApi**: ASP.NET Core Web API exposing the HTTP endpoints
+  (replaces the deprecated **ServerManagement.Functions** project)
 - **Scripts**: PowerShell deployment scripts
 
 ## Configuration
 
-The solution uses environment-based configuration. See [ServerManagement.Functions/README.md](ServerManagement.Functions/README.md) for detailed configuration instructions.
+The solution uses environment-based configuration. See [ServerManagment.WebApi](ServerManagment.WebApi) for detailed configuration instructions.
 
 ## Local Development
 
 1. Ensure prerequisites are installed:
    - .NET 8 SDK
-   - Azure Functions Core Tools v4
    - Azure CLI
 
 2. Set up local configuration:
-   - Copy `ServerManagement.Functions/local.settings.json.example` to `local.settings.json`
-   - Update with your Azure and game server details
+   - Copy `ServerManagment.WebApi/appsettings.Development.json.example` to `appsettings.Development.json` in the same folder
+   - (Optional) copy `ServerManagment.WebApi/appsettings.json.example` to `appsettings.json` for production values
+   - Update the files with your Azure and game server details
 
-3. Run the Functions app:
+3. Run the Web API:
    ```bash
-   cd ServerManagement.Functions
-   func start
+   cd ServerManagment.WebApi
+   dotnet run
    ```
 
 ## Deployment
@@ -51,8 +52,8 @@ The solution follows clean architecture principles:
    - Implements Azure VM management using Azure SDK
    - Implements game server communication via Telnet
 
-3. **API Layer** (`ServerManagement.Functions`):
-   - Exposes HTTP endpoints via Azure Functions
+3. **API Layer** (`ServerManagment.WebApi`):
+   - Exposes HTTP endpoints via ASP.NET Core Web API
    - Handles dependency injection and configuration
 
 ## Security Considerations

--- a/Backend/ServerManagement.sln
+++ b/Backend/ServerManagement.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServerManagement.Functions"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServerManagement.Tests", "ServerManagement.Tests\ServerManagement.Tests.csproj", "{8B191B95-F75D-4FD0-B368-60D7AEFD7C6F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServerManagment.WebApi", "ServerManagment.WebApi\ServerManagment.WebApi.csproj", "{AA73CABA-5C29-4EB4-905B-BA2E8BE2827B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,5 +38,9 @@ Global
 		{8B191B95-F75D-4FD0-B368-60D7AEFD7C6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8B191B95-F75D-4FD0-B368-60D7AEFD7C6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8B191B95-F75D-4FD0-B368-60D7AEFD7C6F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA73CABA-5C29-4EB4-905B-BA2E8BE2827B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA73CABA-5C29-4EB4-905B-BA2E8BE2827B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA73CABA-5C29-4EB4-905B-BA2E8BE2827B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA73CABA-5C29-4EB4-905B-BA2E8BE2827B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Backend/ServerManagment.WebApi/GameEndpoints.cs
+++ b/Backend/ServerManagment.WebApi/GameEndpoints.cs
@@ -1,0 +1,70 @@
+using Microsoft.AspNetCore.Mvc;
+using ServerManagement.Core.Exceptions;
+using ServerManagement.Core.Interfaces;
+using ServerManagement.Core.Models;
+
+namespace ServerManagment.WebApi;
+
+public static class GameEndpoints
+{
+    public static void MapGameEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/game/info", async ([FromServices] IServerManager manager, ILogger<GameEndpoints> logger) =>
+        {
+            try
+            {
+                var info = await manager.GetGameInfoAsync();
+                return Results.Ok(info);
+            }
+            catch (GameServerUnreachableException ex)
+            {
+                logger.LogError(ex, "Game server unreachable");
+                return Results.Json(new ApiErrorResponse
+                {
+                    Code = "GAME_SERVER_UNREACHABLE",
+                    Message = ex.Message,
+                    Details = ex.InnerException?.Message ?? string.Empty
+                }, statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Unexpected error getting game info");
+                return Results.Json(new ApiErrorResponse
+                {
+                    Code = "INTERNAL_ERROR",
+                    Message = "An unexpected error occurred",
+                    Details = ex.Message
+                }, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        });
+
+        app.MapGet("/api/game/players", async ([FromServices] IServerManager manager, ILogger<GameEndpoints> logger) =>
+        {
+            try
+            {
+                var players = await manager.GetPlayersAsync();
+                return Results.Ok(players);
+            }
+            catch (GameServerUnreachableException ex)
+            {
+                logger.LogError(ex, "Game server unreachable");
+                return Results.Json(new ApiErrorResponse
+                {
+                    Code = "GAME_SERVER_UNREACHABLE",
+                    Message = ex.Message,
+                    Details = ex.InnerException?.Message ?? string.Empty
+                }, statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Unexpected error getting players");
+                return Results.Json(new ApiErrorResponse
+                {
+                    Code = "INTERNAL_ERROR",
+                    Message = "An unexpected error occurred",
+                    Details = ex.Message
+                }, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        });
+    }
+}

--- a/Backend/ServerManagment.WebApi/Program.cs
+++ b/Backend/ServerManagment.WebApi/Program.cs
@@ -1,0 +1,32 @@
+using ServerManagement.Azure;
+using ServerManagement.Azure.Configuration;
+using ServerManagement.Core.Interfaces;
+using ServerManagment.WebApi;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Load environment variables
+builder.Configuration.AddEnvironmentVariables();
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddHttpClient();
+
+builder.Services.Configure<AzureVmConfiguration>(builder.Configuration.GetSection("AzureVmConfiguration"));
+builder.Services.Configure<GameServerConfiguration>(builder.Configuration.GetSection("GameServerConfiguration"));
+
+builder.Services.AddScoped<IServerManager, AzureServerManager>();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.MapVmEndpoints();
+app.MapGameEndpoints();
+
+app.Run();

--- a/Backend/ServerManagment.WebApi/Properties/launchSettings.json
+++ b/Backend/ServerManagment.WebApi/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:10941",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5055",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/Backend/ServerManagment.WebApi/README.md
+++ b/Backend/ServerManagment.WebApi/README.md
@@ -1,0 +1,42 @@
+# ServerManagment.WebApi
+
+ASP.NET Core Web API providing HTTP endpoints to manage a 7 Days to Die server running on an Azure VM. This project replaces the earlier `ServerManagement.Functions` Azure Functions app but reuses the same business logic.
+
+## Configuration
+
+Configuration is loaded from environment variables using the same naming convention as the Functions project.
+
+### Environment Variables
+
+| Variable Name | Description |
+|---------------|-------------|
+| `AzureVmConfiguration__SubscriptionId` | Azure Subscription ID |
+| `AzureVmConfiguration__ResourceGroupName` | Resource Group containing the VM |
+| `AzureVmConfiguration__VmName` | Name of the Azure VM |
+| `GameServerConfiguration__Host` | Game server hostname or IP |
+| `GameServerConfiguration__Port` | Game server port |
+| `GameServerConfiguration__TelnetPort` | Telnet admin port |
+| `GameServerConfiguration__AdminPassword` | Telnet admin password |
+
+### Local Development
+
+1. Copy `appsettings.Development.json.example` to `appsettings.Development.json` and fill in your local values.
+2. (Optional) copy `appsettings.json.example` to `appsettings.json` for production settings.
+3. Run the API:
+
+```bash
+cd ServerManagment.WebApi
+dotnet run
+```
+
+Swagger UI will be available at `http://localhost:5000/swagger` by default.
+
+### Available Endpoints
+
+- `GET /api/vm/status` - Returns VM state and game port status
+- `POST /api/vm/start` - Starts the VM
+- `POST /api/vm/stop` - Stops the VM
+- `POST /api/vm/restart` - Restarts the VM
+- `GET /api/game/info` - Returns game server information
+- `GET /api/game/players` - Returns list of online players
+

--- a/Backend/ServerManagment.WebApi/ServerManagment.WebApi.csproj
+++ b/Backend/ServerManagment.WebApi/ServerManagment.WebApi.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ServerManagement.Core\ServerManagement.Core.csproj" />
+    <ProjectReference Include="..\ServerManagement.Azure\ServerManagement.Azure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Backend/ServerManagment.WebApi/VmEndpoints.cs
+++ b/Backend/ServerManagment.WebApi/VmEndpoints.cs
@@ -1,0 +1,131 @@
+using Microsoft.AspNetCore.Mvc;
+using ServerManagement.Core.Interfaces;
+using ServerManagement.Core.Models;
+using ServerManagement.Core.Exceptions;
+
+namespace ServerManagment.WebApi;
+
+public static class VmEndpoints
+{
+    public static void MapVmEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/vm/status", async ([FromServices] IServerManager manager, ILogger<VmEndpoints> logger) =>
+        {
+            try
+            {
+                var status = await manager.GetVmStatusAsync();
+                return Results.Ok(status);
+            }
+            catch (VmOperationException ex)
+            {
+                logger.LogError(ex, "VM operation failed");
+                return Results.Json(new ApiErrorResponse
+                {
+                    Code = "VM_OPERATION_FAILED",
+                    Message = ex.Message,
+                    Details = ex.InnerException?.Message ?? string.Empty
+                }, statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Unexpected error getting VM status");
+                return Results.Json(new ApiErrorResponse
+                {
+                    Code = "INTERNAL_ERROR",
+                    Message = "An unexpected error occurred",
+                    Details = ex.Message
+                }, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        });
+
+        app.MapPost("/api/vm/start", async ([FromServices] IServerManager manager, ILogger<VmEndpoints> logger) =>
+        {
+            try
+            {
+                await manager.StartVmAsync();
+                var status = await manager.GetVmStatusAsync();
+                return Results.Ok(status);
+            }
+            catch (VmOperationException ex)
+            {
+                logger.LogError(ex, "Failed to start VM");
+                return Results.Json(new ApiErrorResponse
+                {
+                    Code = "VM_START_FAILED",
+                    Message = ex.Message,
+                    Details = ex.InnerException?.Message ?? string.Empty
+                }, statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Unexpected error starting VM");
+                return Results.Json(new ApiErrorResponse
+                {
+                    Code = "INTERNAL_ERROR",
+                    Message = "An unexpected error occurred",
+                    Details = ex.Message
+                }, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        });
+
+        app.MapPost("/api/vm/stop", async ([FromServices] IServerManager manager, ILogger<VmEndpoints> logger) =>
+        {
+            try
+            {
+                await manager.StopVmAsync();
+                var status = await manager.GetVmStatusAsync();
+                return Results.Ok(status);
+            }
+            catch (VmOperationException ex)
+            {
+                logger.LogError(ex, "Failed to stop VM");
+                return Results.Json(new ApiErrorResponse
+                {
+                    Code = "VM_STOP_FAILED",
+                    Message = ex.Message,
+                    Details = ex.InnerException?.Message ?? string.Empty
+                }, statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Unexpected error stopping VM");
+                return Results.Json(new ApiErrorResponse
+                {
+                    Code = "INTERNAL_ERROR",
+                    Message = "An unexpected error occurred",
+                    Details = ex.Message
+                }, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        });
+
+        app.MapPost("/api/vm/restart", async ([FromServices] IServerManager manager, ILogger<VmEndpoints> logger) =>
+        {
+            try
+            {
+                await manager.RestartVmAsync();
+                var status = await manager.GetVmStatusAsync();
+                return Results.Ok(status);
+            }
+            catch (VmOperationException ex)
+            {
+                logger.LogError(ex, "Failed to restart VM");
+                return Results.Json(new ApiErrorResponse
+                {
+                    Code = "VM_RESTART_FAILED",
+                    Message = ex.Message,
+                    Details = ex.InnerException?.Message ?? string.Empty
+                }, statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Unexpected error restarting VM");
+                return Results.Json(new ApiErrorResponse
+                {
+                    Code = "INTERNAL_ERROR",
+                    Message = "An unexpected error occurred",
+                    Details = ex.Message
+                }, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        });
+    }
+}

--- a/Backend/ServerManagment.WebApi/appsettings.Development.json.example
+++ b/Backend/ServerManagment.WebApi/appsettings.Development.json.example
@@ -1,0 +1,19 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AzureVmConfiguration": {
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "ResourceGroupName": "my-resource-group",
+    "VmName": "7dtdvm"
+  },
+  "GameServerConfiguration": {
+    "Host": "my-server-url",
+    "Port": 26900,
+    "TelnetPort": 8081,
+    "AdminPassword": "my-telnet-password"
+  }
+}

--- a/Backend/ServerManagment.WebApi/appsettings.json.example
+++ b/Backend/ServerManagment.WebApi/appsettings.json.example
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- deprecate Azure Functions and add `ServerManagment.WebApi` project
- wire up business logic from existing services
- document new API usage and update backend README
- hook project into backend solution
- provide example configuration files and ignore real appsettings

## Testing
- `dotnet test Backend/ServerManagement.sln`


------
https://chatgpt.com/codex/tasks/task_e_6844e27d962c8325b5bfc51afb636c4c